### PR TITLE
Catch empty selection on visualize

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packs (0.0.2)
+    use_packs (0.0.3)
       code_ownership
       colorize
       packwerk (>= 2.2.1)

--- a/lib/use_packs/private/interactive_cli/pack_selector.rb
+++ b/lib/use_packs/private/interactive_cli/pack_selector.rb
@@ -9,24 +9,48 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(ParsePackwerk::Package) }
         def self.single_pack_select(prompt, question_text: 'Please use space to select a pack')
           packs = ParsePackwerk.all.to_h { |t| [t.name, t] }
-          prompt.select(
+          pack_selection = T.let(nil, T.nilable(ParsePackwerk::Package))
+
+          pack_selection = prompt.select(
             question_text,
             packs,
             filter: true,
             per_page: 10,
             show_help: :always
           )
+
+          while pack_selection.nil?
+            prompt.error(
+              'No packs were selected, please select a pack using the space key before pressing enter.'
+            )
+
+            pack_selection = single_pack_select(prompt, question_text: question_text)
+          end
+
+          pack_selection
         end
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[ParsePackwerk::Package]) }
         def self.single_or_all_pack_multi_select(prompt, question_text: 'Please use space to select one or more packs')
-          prompt.multi_select(
+          pack_selection = T.let([], T::Array[ParsePackwerk::Package])
+
+          pack_selection = prompt.multi_select(
             question_text,
             ParsePackwerk.all.to_h { |t| [t.name, t] },
             filter: true,
             per_page: 10,
             show_help: :always
           )
+
+          while pack_selection.empty?
+            prompt.error(
+              'No packs were selected, please select one or more packs using the space key before pressing enter.'
+            )
+
+            pack_selection = single_or_all_pack_multi_select(prompt, question_text: question_text)
+          end
+
+          pack_selection
         end
       end
     end

--- a/lib/use_packs/private/interactive_cli/pack_selector.rb
+++ b/lib/use_packs/private/interactive_cli/pack_selector.rb
@@ -9,15 +9,14 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(ParsePackwerk::Package) }
         def self.single_pack_select(prompt, question_text: 'Please use space to select a pack')
           packs = ParsePackwerk.all.to_h { |t| [t.name, t] }
-          pack_selection = T.let(nil, T.nilable(ParsePackwerk::Package))
 
-          pack_selection = prompt.select(
+          pack_selection = T.let(prompt.select(
             question_text,
             packs,
             filter: true,
             per_page: 10,
             show_help: :always
-          )
+          ), T.nilable(ParsePackwerk::Package))
 
           while pack_selection.nil?
             prompt.error(
@@ -32,15 +31,13 @@ module UsePacks
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[ParsePackwerk::Package]) }
         def self.single_or_all_pack_multi_select(prompt, question_text: 'Please use space to select one or more packs')
-          pack_selection = T.let([], T::Array[ParsePackwerk::Package])
-
-          pack_selection = prompt.multi_select(
+          pack_selection = T.let(prompt.multi_select(
             question_text,
             ParsePackwerk.all.to_h { |t| [t.name, t] },
             filter: true,
             per_page: 10,
             show_help: :always
-          )
+          ), T::Array[ParsePackwerk::Package])
 
           while pack_selection.empty?
             prompt.error(

--- a/lib/use_packs/private/interactive_cli/pack_selector.rb
+++ b/lib/use_packs/private/interactive_cli/pack_selector.rb
@@ -7,7 +7,7 @@ module UsePacks
         extend T::Sig
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(ParsePackwerk::Package) }
-        def self.single_pack_select(prompt, question_text: 'Please select a pack')
+        def self.single_pack_select(prompt, question_text: 'Please use space to select a pack')
           packs = ParsePackwerk.all.to_h { |t| [t.name, t] }
           prompt.select(
             question_text,
@@ -19,7 +19,7 @@ module UsePacks
         end
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[ParsePackwerk::Package]) }
-        def self.single_or_all_pack_multi_select(prompt, question_text: 'Please select one or more packs')
+        def self.single_or_all_pack_multi_select(prompt, question_text: 'Please use space to select one or more packs')
           prompt.multi_select(
             question_text,
             ParsePackwerk.all.to_h { |t| [t.name, t] },

--- a/lib/use_packs/private/interactive_cli/team_selector.rb
+++ b/lib/use_packs/private/interactive_cli/team_selector.rb
@@ -7,7 +7,7 @@ module UsePacks
         extend T::Sig
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(CodeTeams::Team) }
-        def self.single_select(prompt, question_text: 'Please select a team owner')
+        def self.single_select(prompt, question_text: 'Please use space to select a team owner')
           teams = CodeTeams.all.sort_by(&:name).to_h { |t| [t.name, t] }
           prompt.select(
             question_text,
@@ -19,7 +19,7 @@ module UsePacks
         end
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[CodeTeams::Team]) }
-        def self.multi_select(prompt, question_text: 'Please select team owners')
+        def self.multi_select(prompt, question_text: 'Please use space to select team owners')
           teams = CodeTeams.all.to_h { |t| [t.name, t] }
           prompt.multi_select(
             question_text,

--- a/lib/use_packs/private/interactive_cli/team_selector.rb
+++ b/lib/use_packs/private/interactive_cli/team_selector.rb
@@ -9,26 +9,49 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(CodeTeams::Team) }
         def self.single_select(prompt, question_text: 'Please use space to select a team owner')
           teams = CodeTeams.all.sort_by(&:name).to_h { |t| [t.name, t] }
-          prompt.select(
+          team_selection = T.let(nil, T.nilable(CodeTeams::Team))
+
+          team_selection = prompt.select(
             question_text,
             teams,
             filter: true,
             per_page: 10,
             show_help: :always
           )
+
+          while team_selection.nil?
+            prompt.error(
+              'No owners were selected, please select an owner using the space key before pressing enter.'
+            )
+
+            team_selection = single_select(prompt, question_text: question_text)
+          end
+
+          team_selection
         end
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[CodeTeams::Team]) }
         def self.multi_select(prompt, question_text: 'Please use space to select team owners')
           teams = CodeTeams.all.to_h { |t| [t.name, t] }
-          # require 'pry'; binding.pry
-          prompt.multi_select(
+          team_selection = T.let([], T::Array[CodeTeams::Team])
+
+          team_selection = prompt.multi_select(
             question_text,
             teams,
             filter: true,
             per_page: 10,
             show_help: :always
           )
+
+          while team_selection.empty?
+            prompt.error(
+              'No owners were selected, please select one or more owners using the space key before pressing enter.'
+            )
+
+            team_selection = multi_select(prompt, question_text: question_text)
+          end
+
+          team_selection
         end
       end
     end

--- a/lib/use_packs/private/interactive_cli/team_selector.rb
+++ b/lib/use_packs/private/interactive_cli/team_selector.rb
@@ -9,15 +9,14 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(CodeTeams::Team) }
         def self.single_select(prompt, question_text: 'Please use space to select a team owner')
           teams = CodeTeams.all.sort_by(&:name).to_h { |t| [t.name, t] }
-          team_selection = T.let(nil, T.nilable(CodeTeams::Team))
 
-          team_selection = prompt.select(
+          team_selection = T.let(prompt.select(
             question_text,
             teams,
             filter: true,
             per_page: 10,
             show_help: :always
-          )
+          ), T.nilable(CodeTeams::Team))
 
           while team_selection.nil?
             prompt.error(
@@ -33,15 +32,14 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[CodeTeams::Team]) }
         def self.multi_select(prompt, question_text: 'Please use space to select team owners')
           teams = CodeTeams.all.to_h { |t| [t.name, t] }
-          team_selection = T.let([], T::Array[CodeTeams::Team])
 
-          team_selection = prompt.multi_select(
+          team_selection = T.let(prompt.multi_select(
             question_text,
             teams,
             filter: true,
             per_page: 10,
             show_help: :always
-          )
+          ), T::Array[CodeTeams::Team])
 
           while team_selection.empty?
             prompt.error(

--- a/lib/use_packs/private/interactive_cli/team_selector.rb
+++ b/lib/use_packs/private/interactive_cli/team_selector.rb
@@ -21,6 +21,7 @@ module UsePacks
         sig { params(prompt: TTY::Prompt, question_text: String).returns(T::Array[CodeTeams::Team]) }
         def self.multi_select(prompt, question_text: 'Please use space to select team owners')
           teams = CodeTeams.all.to_h { |t| [t.name, t] }
+          # require 'pry'; binding.pry
           prompt.multi_select(
             question_text,
             teams,

--- a/lib/use_packs/private/interactive_cli/use_cases/visualize.rb
+++ b/lib/use_packs/private/interactive_cli/use_cases/visualize.rb
@@ -19,18 +19,35 @@ module UsePacks
               teams = TeamSelector.multi_select(prompt)
               VisualizePackwerk.team_graph!(teams)
             else
-              by_name_or_by_owner = prompt.select('Do you select packs by name or by owner?', ['By name', 'By owner'])
+              by_name_or_by_owner = prompt.select(
+                'Do you select packs by name or by owner?',
+                ['By name', 'By owner']
+              )
 
-              if by_name_or_by_owner == 'By owner'
-                teams = TeamSelector.multi_select(prompt)
-                selected_packs = ParsePackwerk.all.select do |p|
-                  teams.map(&:name).include?(CodeOwnership.for_package(p)&.name)
-                end
-              else
-                selected_packs = PackSelector.single_or_all_pack_multi_select(prompt)
+              selected_packs = get_selected_packs(prompt, select_by: by_name_or_by_owner)
+
+              while selected_packs.empty?
+                prompt.error(
+                  'No owners were selected, please select an owner using the space key before pressing enter.'
+                )
+
+                selected_packs = get_selected_packs(prompt, select_by: by_name_or_by_owner)
               end
 
               VisualizePackwerk.package_graph!(selected_packs)
+            end
+          end
+
+          sig { params(prompt: TTY::Prompt, select_by: String).returns(T::Array[ParsePackwerk::Package]) }
+          def get_selected_packs(prompt, select_by:)
+            if select_by == 'By owner'
+              teams = TeamSelector.multi_select(prompt)
+
+              ParsePackwerk.all.select do |p|
+                teams.map(&:name).include?(CodeOwnership.for_package(p)&.name)
+              end
+            else
+              PackSelector.single_or_all_pack_multi_select(prompt)
             end
           end
 

--- a/lib/use_packs/private/interactive_cli/use_cases/visualize.rb
+++ b/lib/use_packs/private/interactive_cli/use_cases/visualize.rb
@@ -20,6 +20,7 @@ module UsePacks
               VisualizePackwerk.team_graph!(teams)
             else
               by_name_or_by_owner = prompt.select('Do you select packs by name or by owner?', ['By name', 'By owner'])
+
               if by_name_or_by_owner == 'By owner'
                 teams = TeamSelector.multi_select(prompt)
                 selected_packs = ParsePackwerk.all.select do |p|

--- a/spec/use_packs/private/interactive_cli_spec.rb
+++ b/spec/use_packs/private/interactive_cli_spec.rb
@@ -141,12 +141,19 @@ module UsePacks
 
       prompt.input << "Artists" # Please select team owners
       # prompt.input << INPUTS::SPACE # We "forgot" to use space here! (simulate failure case)
+      prompt.input << INPUTS::RETURN # (submit invalid)
+
+      # ...please select an owner using the space key before pressing enter.
+
+      prompt.input << "Artists" # Please select team owners
+      prompt.input << INPUTS::SPACE # Rememebered the space this time
       prompt.input << INPUTS::RETURN # (Confirm selection)
+
       prompt.input << INPUTS::EOF
 
       prompt.input.rewind
 
-      expect(VisualizePackwerk).to receive(:package_graph!).with([])
+      expect(VisualizePackwerk).to receive(:package_graph!).with([ParsePackwerk.all.first])
 
       subject
     end

--- a/spec/use_packs/private/interactive_cli_spec.rb
+++ b/spec/use_packs/private/interactive_cli_spec.rb
@@ -10,7 +10,7 @@ module UsePacks
     RIGHT = "\e[C"
 
     RETURN = "\r"
-    SPACE = " " # For multi-select to make this explicit
+    SPACE = ' ' # For multi-select to make this explicit
     EOF = "\C-d" # Ctrl-D - End of File
   end
 
@@ -115,7 +115,7 @@ module UsePacks
       prompt.input << INPUTS::DOWN # Do you select packs by name or by owner?
       prompt.input << INPUTS::RETURN # (Confirms 'owner')
 
-      prompt.input << "Artists" # Please select team owners
+      prompt.input << 'Artists' # Please select team owners
       prompt.input << INPUTS::SPACE # (Select it)
       prompt.input << INPUTS::RETURN # (Confirm selection)
       prompt.input << INPUTS::EOF
@@ -139,13 +139,13 @@ module UsePacks
       prompt.input << INPUTS::DOWN # Do you select packs by name or by owner?
       prompt.input << INPUTS::RETURN # (Confirms 'owner')
 
-      prompt.input << "Artists" # Please select team owners
+      prompt.input << 'Artists' # Please select team owners
       # prompt.input << INPUTS::SPACE # We "forgot" to use space here! (simulate failure case)
       prompt.input << INPUTS::RETURN # (submit invalid)
 
       # ...please select an owner using the space key before pressing enter.
 
-      prompt.input << "Artists" # Please select team owners
+      prompt.input << 'Artists' # Please select team owners
       prompt.input << INPUTS::SPACE # Rememebered the space this time
       prompt.input << INPUTS::RETURN # (Confirm selection)
 

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Catches the case when someone uses enter rather than space to select a team/name, warns, and cycles the process.