### PR TITLE
Support simpler happy path for bin/packs move and make public

### DIFF
--- a/lib/use_packs/private/interactive_cli.rb
+++ b/lib/use_packs/private/interactive_cli.rb
@@ -5,6 +5,7 @@ require 'tty-prompt'
 
 require 'use_packs/private/interactive_cli/team_selector'
 require 'use_packs/private/interactive_cli/pack_selector'
+require 'use_packs/private/interactive_cli/file_selector'
 require 'use_packs/private/interactive_cli/use_cases/interface'
 require 'use_packs/private/interactive_cli/use_cases/create'
 require 'use_packs/private/interactive_cli/use_cases/move'

--- a/lib/use_packs/private/interactive_cli/file_selector.rb
+++ b/lib/use_packs/private/interactive_cli/file_selector.rb
@@ -1,0 +1,26 @@
+# typed: strict
+
+module UsePacks
+  module Private
+    module InteractiveCli
+      class FileSelector
+        extend T::Sig
+
+        sig { params(prompt: TTY::Prompt).returns(T::Array[String]) }
+        def self.select(prompt)
+          prompt.on(:keytab) do
+            raw_paths_relative_to_root = prompt.multiline('Please copy in a space or new line separated list of files or directories')
+            paths_relative_to_root = T.let([], T::Array[String])
+            raw_paths_relative_to_root.each do |path|
+              paths_relative_to_root += path.chomp.split
+            end
+
+            return paths_relative_to_root
+          end
+
+          [prompt.ask('Please input a file or directory to move (press tab to enter multiline mode)')]
+        end
+      end
+    end
+  end
+end

--- a/lib/use_packs/private/interactive_cli/use_cases/make_public.rb
+++ b/lib/use_packs/private/interactive_cli/use_cases/make_public.rb
@@ -16,11 +16,7 @@ module UsePacks
 
           sig { override.params(prompt: TTY::Prompt).void }
           def perform!(prompt)
-            raw_paths_relative_to_root = prompt.multiline('Please copy in a space or new line separated list of files or directories to make public')
-            paths_relative_to_root = T.let([], T::Array[String])
-            raw_paths_relative_to_root.each do |path|
-              paths_relative_to_root += path.chomp.split
-            end
+            paths_relative_to_root = FileSelector.select(prompt)
 
             UsePacks.make_public!(
               paths_relative_to_root: paths_relative_to_root,

--- a/lib/use_packs/private/interactive_cli/use_cases/move.rb
+++ b/lib/use_packs/private/interactive_cli/use_cases/move.rb
@@ -12,11 +12,7 @@ module UsePacks
           sig { override.params(prompt: TTY::Prompt).void }
           def perform!(prompt)
             pack = PackSelector.single_pack_select(prompt, question_text: 'Please select a destination pack')
-            raw_paths_relative_to_root = prompt.multiline('Please copy in a space or new line separated list of files or directories')
-            paths_relative_to_root = T.let([], T::Array[String])
-            raw_paths_relative_to_root.each do |path|
-              paths_relative_to_root += path.chomp.split
-            end
+            paths_relative_to_root = FileSelector.select(prompt)
 
             UsePacks.move_to_pack!(
               pack_name: pack.name,

--- a/spec/use_packs/private/interactive_cli_spec.rb
+++ b/spec/use_packs/private/interactive_cli_spec.rb
@@ -9,6 +9,7 @@ module UsePacks
     LEFT = "\e[D"
     RIGHT = "\e[C"
 
+    TAB = "\t"
     RETURN = "\r"
     SPACE = ' ' # For multi-select to make this explicit
     EOF = "\C-d" # Ctrl-D - End of File
@@ -58,8 +59,21 @@ module UsePacks
       subject
     end
 
-    it 'allows making files public interactively' do
+    it 'allows making files public interactively in single-line mode' do
       prompt.input << "public\r"
+      prompt.input << "packs/my_pack/path/to/file.rb\r"
+      prompt.input << INPUTS::EOF
+      prompt.input.rewind
+      expect(UsePacks).to receive(:make_public!).with(
+        paths_relative_to_root: ['packs/my_pack/path/to/file.rb'],
+        per_file_processors: anything
+      )
+      subject
+    end
+
+    it 'allows making files public interactively in multi-line mode' do
+      prompt.input << "public\r"
+      prompt.input << INPUTS::TAB
       prompt.input << "packs/my_pack/path/to/file.rb\r"
       prompt.input << "packs/my_pack/path/to/other_file.rb\r"
       prompt.input << INPUTS::EOF
@@ -71,26 +85,26 @@ module UsePacks
       subject
     end
 
-    it 'allows moving files interactively' do
+    it 'allows moving files interactively in single-line mode' do
       write_package_yml('packs/my_destination_pack')
       prompt.input << "Move\r"
       prompt.input << "my_destination_pack\r"
       prompt.input << "packs/my_pack/path/to/file.rb\r"
-      prompt.input << "packs/my_pack/path/to/other_file.rb\r"
       prompt.input << INPUTS::EOF
       prompt.input.rewind
       expect(UsePacks).to receive(:move_to_pack!).with(
         pack_name: 'packs/my_destination_pack',
-        paths_relative_to_root: ['packs/my_pack/path/to/file.rb', 'packs/my_pack/path/to/other_file.rb'],
+        paths_relative_to_root: ['packs/my_pack/path/to/file.rb'],
         per_file_processors: anything
       )
       subject
     end
 
-    it 'allows moving files interactively' do
+    it 'allows moving files interactively in multi-line mode' do
       write_package_yml('packs/my_destination_pack')
       prompt.input << "Move\r"
       prompt.input << "my_destination_pack\r"
+      prompt.input << INPUTS::TAB
       prompt.input << "packs/my_pack/path/to/file.rb\r"
       prompt.input << "packs/my_pack/path/to/other_file.rb\r"
       prompt.input << INPUTS::EOF


### PR DESCRIPTION
Watching users use `bin/packs`, it became clear that they expect "enter" to move a file or make it public. Instead, it goes to a new line and asks them to use the unfamiliar "ctrl+d" to advance.

Most of the time, users are moving or making public single files. Therefore, we make the happy path reflect that and permit a user to enter multi-line mode with "tab."
