### PR TITLE
Use T.untyped instead of Packwerk::OffenseCollection temporarily

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in use_packs.gemspec
 gemspec
 
-gem 'packwerk', git: 'https://github.com/Shopify/packwerk', branch: 'main'
+gem 'packwerk', github: 'Shopify/packwerk', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/Shopify/packwerk
-  revision: af7b0aa2a2aa3920b398b50fd8beac902a92ed26
+  remote: https://github.com/Shopify/packwerk.git
+  revision: 8476bb3cd5452765ad452d36aa45ae724f1d44f5
   branch: main
   specs:
     packwerk (2.2.1)
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.5)
+    use_packs (0.0.6)
       code_ownership
       colorize
       packwerk
@@ -78,7 +78,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
-    parse_packwerk (0.16.0)
+    parse_packwerk (0.17.0)
       sorbet-runtime
     parser (3.1.2.0)
       ast (~> 2.4.1)

--- a/lib/use_packs/private/packwerk_wrapper/offenses_aggregator_formatter.rb
+++ b/lib/use_packs/private/packwerk_wrapper/offenses_aggregator_formatter.rb
@@ -24,7 +24,9 @@ module UsePacks
           ''
         end
 
-        sig { override.params(offense_collection: Packwerk::OffenseCollection, for_files: T::Set[String]).returns(String) }
+        # T.untyped should be Packwerk::OffenseCollection, but is currently private until
+        # https://github.com/Shopify/packwerk/pull/289 merges
+        sig { override.params(offense_collection: T.untyped, for_files: T::Set[String]).returns(String) }
         def show_stale_violations(offense_collection, for_files)
           ''
         end

--- a/sorbet/rbi/gems/packwerk@2.2.1-8476bb3cd5452765ad452d36aa45ae724f1d44f5.rbi
+++ b/sorbet/rbi/gems/packwerk@2.2.1-8476bb3cd5452765ad452d36aa45ae724f1d44f5.rbi
@@ -317,23 +317,7 @@ class Packwerk::ConstNodeInspector
   def root_constant?(parent); end
 end
 
-class Packwerk::ConstantDiscovery
-  sig { params(constant_resolver: ::ConstantResolver, packages: Packwerk::PackageSet).void }
-  def initialize(constant_resolver:, packages:); end
-
-  sig do
-    params(
-      const_name: ::String,
-      current_namespace_path: T.nilable(T::Array[::String])
-    ).returns(T.nilable(::Packwerk::ConstantDiscovery::ConstantContext))
-  end
-  def context_for(const_name, current_namespace_path: T.unsafe(nil)); end
-
-  sig { params(path: ::String).returns(::Packwerk::Package) }
-  def package_from_path(path); end
-end
-
-class Packwerk::ConstantDiscovery::ConstantContext < ::Struct
+class Packwerk::ConstantContext < ::Struct
   def location; end
   def location=(_); end
   def name; end
@@ -347,6 +331,22 @@ class Packwerk::ConstantDiscovery::ConstantContext < ::Struct
     def members; end
     def new(*_arg0); end
   end
+end
+
+class Packwerk::ConstantDiscovery
+  sig { params(constant_resolver: ::ConstantResolver, packages: Packwerk::PackageSet).void }
+  def initialize(constant_resolver:, packages:); end
+
+  sig do
+    params(
+      const_name: ::String,
+      current_namespace_path: T.nilable(T::Array[::String])
+    ).returns(T.nilable(::Packwerk::ConstantContext))
+  end
+  def context_for(const_name, current_namespace_path: T.unsafe(nil)); end
+
+  sig { params(path: ::String).returns(::Packwerk::Package) }
+  def package_from_path(path); end
 end
 
 module Packwerk::ConstantNameInspector
@@ -588,7 +588,7 @@ class Packwerk::Graph
   def visit(node, visited_nodes: T.unsafe(nil), path: T.unsafe(nil)); end
 end
 
-class Packwerk::Node; end
+module Packwerk::Node; end
 
 class Packwerk::Node::Location < ::Struct
   def column; end
@@ -1080,7 +1080,7 @@ class Packwerk::Parsers::Erb
   sig { override.params(io: T.any(::IO, ::StringIO), file_path: ::String).returns(T.untyped) }
   def call(io:, file_path: T.unsafe(nil)); end
 
-  sig { params(buffer: ::Parser::Source::Buffer, file_path: ::String).returns(T.untyped) }
+  sig { params(buffer: ::Parser::Source::Buffer, file_path: ::String).returns(T.nilable(::AST::Node)) }
   def parse_buffer(buffer, file_path:); end
 
   private
@@ -1093,7 +1093,7 @@ class Packwerk::Parsers::Erb
   end
   def code_nodes(node, &block); end
 
-  sig { params(erb_ast: T.all(::AST::Node, ::Object), file_path: ::String).returns(::AST::Node) }
+  sig { params(erb_ast: T.all(::AST::Node, ::Object), file_path: ::String).returns(T.nilable(::AST::Node)) }
   def to_ruby_ast(erb_ast, file_path); end
 end
 
@@ -1140,7 +1140,7 @@ class Packwerk::Parsers::Ruby
   sig { params(parser_class: T.untyped).void }
   def initialize(parser_class: T.unsafe(nil)); end
 
-  sig { override.params(io: T.any(::IO, ::StringIO), file_path: ::String).returns(T.untyped) }
+  sig { override.params(io: T.any(::IO, ::StringIO), file_path: ::String).returns(T.nilable(::Parser::AST::Node)) }
   def call(io:, file_path: T.unsafe(nil)); end
 end
 

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.5'
+  spec.version       = '0.0.6'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
This is temporary! Will allow us to get on packwerk `main` in the gusto monolith.