### PR TITLE
Run bin/packwerk validate when adding a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.8)
+    use_packs (0.0.9)
       code_ownership
       colorize
       packwerk

--- a/lib/use_packs/private.rb
+++ b/lib/use_packs/private.rb
@@ -292,6 +292,7 @@ module UsePacks
         metadata: package.metadata
       )
       ParsePackwerk.write_package_yml!(new_package)
+      PackwerkWrapper.validate!
     end
 
     sig { params(file_move_operation: FileMoveOperation, per_file_processors: T::Array[UsePacks::PerFileProcessorInterface]).void }

--- a/lib/use_packs/private/packwerk_wrapper.rb
+++ b/lib/use_packs/private/packwerk_wrapper.rb
@@ -8,13 +8,6 @@ module UsePacks
     module PackwerkWrapper
       extend T::Sig
 
-      sig { params(argv: T.untyped, formatter: Packwerk::OffensesFormatter).void }
-      def self.packwerk_cli_run_safely(argv, formatter)
-        with_safe_exit_if_no_files_found do
-          packwerk_cli(formatter).run(argv)
-        end
-      end
-
       #
       # execute_command is like `run` except it does not `exit`
       #

--- a/lib/use_packs/private/packwerk_wrapper.rb
+++ b/lib/use_packs/private/packwerk_wrapper.rb
@@ -46,6 +46,12 @@ module UsePacks
         formatter.aggregated_offenses.compact
       end
 
+      sig { void }
+      def self.validate!
+        formatter = OffensesAggregatorFormatter.new
+        packwerk_cli_execute_safely(['validate'], formatter)
+      end
+
       sig { params(files: T::Array[String]).returns(T::Array[Packwerk::ReferenceOffense]) }
       def self.get_offenses_for_files_by_package(files)
         packages = package_names_for_files(files)

--- a/lib/use_packs/user_event_logger.rb
+++ b/lib/use_packs/user_event_logger.rb
@@ -83,9 +83,7 @@ module UsePacks
       <<~MSG
         Your next steps might be:
 
-        1) Run `bin/packwerk validate` to ensure you haven't introduced a cyclic dependency
-
-        2) Run `bin/packwerk update-todo` to update the violations.
+        1) Run `bin/packwerk update-todo` to update the violations.
       MSG
     end
 

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.8'
+  spec.version       = '0.0.9'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Adding a dependency can result in a cycle, so we automatically run validate to give users that feedback.
