### PR TITLE
Have bin/packs check use PackwerkWrapper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.9)
+    use_packs (0.0.10)
       code_ownership
       colorize
       packwerk
@@ -130,7 +130,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.31)
+    rubocop-packs (0.0.32)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/use_packs/cli.rb
+++ b/lib/use_packs/cli.rb
@@ -99,7 +99,7 @@ module UsePacks
     desc 'check [ packs/my_pack ]', 'Run bin/packwerk check'
     sig { params(paths: String).void }
     def check(*paths)
-      system("bin/packwerk check #{paths.join(' ')}")
+      UsePacks.execute(['check', *paths])
     end
 
     desc 'update [ packs/my_pack ]', 'Run bin/packwerk update-todo'

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.9'
+  spec.version       = '0.0.10'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Currently, `bin/packwerk check` will fail if passed a file that doesn't apply to the include and exclude paths that packwerk looks at.

However, the expected behavior is for packwerk to succeed, since there were no failures on the inputted files. This is an issue with pre-commit hooks, which will provide the user feedback there was a packwerk issue when really we were just testing the staged files to be committed. We could push this complexity to the pre-commit hook, but there's not a clear way for how to ask packwerk what files *would* be included. For now, we use the packwerk wrapper to address this.
