### PR TITLE
Update docs on bin/packs update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.11)
+    use_packs (0.0.12)
       code_ownership
       colorize
       packwerk

--- a/lib/use_packs/cli.rb
+++ b/lib/use_packs/cli.rb
@@ -102,10 +102,10 @@ module UsePacks
       UsePacks.execute(['check', *paths])
     end
 
-    desc 'update [ packs/my_pack ]', 'Run bin/packwerk update-todo'
-    sig { params(paths: String).void }
-    def update(*paths)
-      system("bin/packwerk update-todo #{paths.join(' ')}")
+    desc 'update', 'Run bin/packwerk update-todo'
+    sig { void }
+    def update
+      system('bin/packwerk update-todo')
     end
 
     desc 'regenerate_rubocop_todo [ packs/my_pack packs/my_other_pack ]', "Regenerate packs/*/#{RuboCop::Packs::PACK_LEVEL_RUBOCOP_TODO_YML} for one or more packs"

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.11'
+  spec.version       = '0.0.12'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Packwerk 3 doesn't permit arguments to be passed into `bin/packwerk update-todo`
