### PR TITLE
Bump rubocop-packs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.36)
+    rubocop-packs (0.0.34)
       activesupport
       packs
       parse_packwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.34)
+    rubocop-packs (0.0.37)
       activesupport
       packs
       parse_packwerk

--- a/sorbet/rbi/gems/rubocop-packs@0.0.33.rbi
+++ b/sorbet/rbi/gems/rubocop-packs@0.0.33.rbi
@@ -27,9 +27,6 @@ class RuboCop::Cop::Packs::DocumentedPublicApis < ::RuboCop::Cop::Style::Documen
   sig { params(node: T.untyped).void }
   def check(node); end
 
-  sig { params(node: T.untyped).returns(T::Boolean) }
-  def node_is_sorbet_signature?(node); end
-
   sig { returns(T::Boolean) }
   def support_autocorrect?; end
 end
@@ -162,6 +159,9 @@ module RuboCop::Packs
     sig { params(rule: ::String).returns(T::Set[::String]) }
     def exclude_for_rule(rule); end
 
+    sig { params(root_pathname: ::String).returns(::String) }
+    def pack_based_rubocop_config(root_pathname: T.unsafe(nil)); end
+
     sig { params(packs: T::Array[::Packs::Pack], files: T::Array[::String]).void }
     def regenerate_todo(packs: T.unsafe(nil), files: T.unsafe(nil)); end
 
@@ -173,6 +173,7 @@ module RuboCop::Packs
   end
 end
 
+RuboCop::Packs::CONFIG = T.let(T.unsafe(nil), Hash)
 RuboCop::Packs::CONFIG_DEFAULT = T.let(T.unsafe(nil), Pathname)
 
 module RuboCop::Packs::Inject

--- a/sorbet/rbi/gems/rubocop-packs@0.0.37.rbi
+++ b/sorbet/rbi/gems/rubocop-packs@0.0.37.rbi
@@ -27,6 +27,9 @@ class RuboCop::Cop::Packs::DocumentedPublicApis < ::RuboCop::Cop::Style::Documen
   sig { params(node: T.untyped).void }
   def check(node); end
 
+  sig { params(node: T.untyped).returns(T::Boolean) }
+  def node_is_sorbet_signature?(node); end
+
   sig { returns(T::Boolean) }
   def support_autocorrect?; end
 end
@@ -173,7 +176,6 @@ module RuboCop::Packs
   end
 end
 
-RuboCop::Packs::CONFIG = T.let(T.unsafe(nil), Hash)
 RuboCop::Packs::CONFIG_DEFAULT = T.let(T.unsafe(nil), Pathname)
 
 module RuboCop::Packs::Inject

--- a/spec/use_packs_spec.rb
+++ b/spec/use_packs_spec.rb
@@ -535,18 +535,18 @@ RSpec.describe UsePacks do
           end
         end
 
-        context 'origin pack has a pack-level .rubocop_todo.yml, destination pack does not' do
-          it 'modifies packs/*/.rubocop_todo.yml, correctly' do
-            write_file('packs/foo/.rubocop_todo.yml', <<~CONTENTS)
+        context 'origin pack has a pack-level package_rubocop_todo.yml, destination pack does not' do
+          it 'modifies packs/*pack_package_rubocop_todo.yml, correctly' do
+            write_file('packs/foo/package_rubocop_todo.yml', <<~CONTENTS)
               ---
               Layout/BeginEndAlignment:
                 Exclude:
                 - packs/foo/app/services/foo.rb
             CONTENTS
 
-            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(before_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/foo/app/services/foo.rb'] } })
-            expect(Pathname.new('packs/barpack_.rubocop_todo.yml')).to_not exist
+            expect(Pathname.new('packs/barpack_package_rubocop_todo.yml')).to_not exist
 
             write_file('packs/foo/app/services/foo.rb')
             UsePacks.create_pack!(pack_name: 'packs/bar')
@@ -558,32 +558,32 @@ RSpec.describe UsePacks do
               per_file_processors: [UsePacks::RubocopPostProcessor.new]
             )
 
-            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => [] } })
-            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/.rubocop_todo.yml'))
+            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_bar).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/bar/app/services/foo.rb'] } })
           end
         end
 
         context 'origin and destination pack both have .rubocop_todo.yml' do
-          it 'modifies packs/*/.rubocop_todo.yml, correctly' do
-            write_file('packs/foo/.rubocop_todo.yml', <<~CONTENTS)
+          it 'modifies packs/*/package_rubocop_todo.yml, correctly' do
+            write_file('packs/foo/package_rubocop_todo.yml', <<~CONTENTS)
               ---
               Layout/BeginEndAlignment:
                 Exclude:
                 - packs/foo/app/services/foo.rb
             CONTENTS
 
-            write_file('packs/bar/.rubocop_todo.yml', <<~CONTENTS)
+            write_file('packs/bar/package_rubocop_todo.yml', <<~CONTENTS)
               ---
               Layout/BeginEndAlignment:
                 Exclude:
                 - packs/bar/app/services/bar.rb
             CONTENTS
 
-            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(before_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/foo/app/services/foo.rb'] } })
-            before_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/.rubocop_todo.yml'))
+            before_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/package_rubocop_todo.yml'))
             expect(before_rubocop_todo_bar).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/bar/app/services/bar.rb'] } })
 
             write_file('packs/foo/app/services/foo.rb')
@@ -596,32 +596,32 @@ RSpec.describe UsePacks do
               per_file_processors: [UsePacks::RubocopPostProcessor.new]
             )
 
-            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => [] } })
-            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/.rubocop_todo.yml'))
+            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_bar).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/bar/app/services/bar.rb', 'packs/bar/app/services/foo.rb'] } })
           end
         end
 
         context 'destination pack does not have same key in .rubocop_todo.yml' do
-          it 'modifies packs/*/.rubocop_todo.yml, correctly' do
-            write_file('packs/foo/.rubocop_todo.yml', <<~CONTENTS)
+          it 'modifies packs/*/package_rubocop_todo.yml, correctly' do
+            write_file('packs/foo/package_rubocop_todo.yml', <<~CONTENTS)
               ---
               Layout/BeginEndAlignment:
                 Exclude:
                 - packs/foo/app/services/foo.rb
             CONTENTS
 
-            write_file('packs/bar/.rubocop_todo.yml', <<~CONTENTS)
+            write_file('packs/bar/package_rubocop_todo.yml', <<~CONTENTS)
               ---
               Layout/OtherCop:
                 Exclude:
                 - packs/bar/app/services/bar.rb
             CONTENTS
 
-            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            before_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(before_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/foo/app/services/foo.rb'] } })
-            before_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/.rubocop_todo.yml'))
+            before_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/package_rubocop_todo.yml'))
             expect(before_rubocop_todo_bar).to eq({ 'Layout/OtherCop' => { 'Exclude' => ['packs/bar/app/services/bar.rb'] } })
 
             write_file('packs/foo/app/services/foo.rb')
@@ -634,9 +634,9 @@ RSpec.describe UsePacks do
               per_file_processors: [UsePacks::RubocopPostProcessor.new]
             )
 
-            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/.rubocop_todo.yml'))
+            after_rubocop_todo_foo = YAML.load_file(Pathname.new('packs/foo/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_foo).to eq({ 'Layout/BeginEndAlignment' => { 'Exclude' => [] } })
-            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/.rubocop_todo.yml'))
+            after_rubocop_todo_bar = YAML.load_file(Pathname.new('packs/bar/package_rubocop_todo.yml'))
             expect(after_rubocop_todo_bar).to eq({
                                                    'Layout/BeginEndAlignment' => { 'Exclude' => ['packs/bar/app/services/foo.rb'] },
                                                    'Layout/OtherCop' => { 'Exclude' => ['packs/bar/app/services/bar.rb'] }
@@ -1029,7 +1029,7 @@ RSpec.describe UsePacks do
       it 'replaces the file in the pack-specific .rubocop_todo.yml' do
         write_package_yml('packs/organisms')
 
-        write_file('packs/organisms/.rubocop_todo.yml', <<~CONTENTS)
+        write_file('packs/organisms/package_rubocop_todo.yml', <<~CONTENTS)
           ---
           Layout/BeginEndAlignment:
             Exclude:
@@ -1039,7 +1039,7 @@ RSpec.describe UsePacks do
         write_file('packs/organisms/app/services/other_bird.rb')
         write_file('packs/organisms/spec/services/other_bird_spec.rb')
 
-        rubocop_todo = Pathname.new('packs/organisms/.rubocop_todo.yml')
+        rubocop_todo = Pathname.new('packs/organisms/package_rubocop_todo.yml')
 
         expect(rubocop_todo.read).to include 'packs/organisms/app/services/other_bird.rb'
         expect(rubocop_todo.read).to_not include 'packs/organisms/app/public/other_bird.rb'


### PR DESCRIPTION
This is mostly a revert, as we need to address performance issues associated with multiple `packs/*/.rubocop.yml`.

Commits:
- Revert "Bump rubocop-packs (#79)"
- bump rubocop packs
