### PR TITLE
Allow bin/packs commands to work without rubocop installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.17)
+    use_packs (0.0.18)
       code_ownership
       colorize
       packs
@@ -136,7 +136,7 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-capybara (2.17.1)
       rubocop (~> 1.41)
-    rubocop-packs (0.0.37)
+    rubocop-packs (0.0.38)
       activesupport
       packs
       parse_packwerk

--- a/lib/use_packs/rubocop_post_processor.rb
+++ b/lib/use_packs/rubocop_post_processor.rb
@@ -7,6 +7,8 @@ module UsePacks
 
     sig { override.params(file_move_operation: Private::FileMoveOperation).void }
     def before_move_file!(file_move_operation)
+      return unless rubocop_enabled?
+
       relative_path_to_origin = file_move_operation.origin_pathname
       relative_path_to_destination = file_move_operation.destination_pathname
 
@@ -50,6 +52,8 @@ module UsePacks
 
     sig { params(file_move_operations: T::Array[Private::FileMoveOperation]).void }
     def after_move_files!(file_move_operations)
+      return unless rubocop_enabled?
+
       # There could also be no TODOs for this file, but moving it produced TODOs. This could happen if:
       # 1) The origin pack did not enforce a rubocop, such as typed public APIs
       # 2) The file satisfied the cop in the origin pack, such as the Packs/RootNamespaceIsPackName, but the desired
@@ -62,6 +66,11 @@ module UsePacks
       end
 
       RuboCop::Packs.regenerate_todo(files: files)
+    end
+
+    sig { returns(T::Boolean) }
+    def rubocop_enabled?
+      Pathname.new('.rubocop.yml').exist?
     end
   end
 end

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.17'
+  spec.version       = '0.0.18'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
I'd expect most clients to be using rubocop, but in case they don't, `bin/packs` commands should not break.
