### PR TITLE
Set owner key to top-level of new pack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GIT
 PATH
   remote: .
   specs:
-    use_packs (0.0.18)
-      code_ownership
+    use_packs (0.0.19)
+      code_ownership (>= 1.33.0)
       colorize
       packs
       packwerk
@@ -105,7 +105,7 @@ GEM
     rbi (0.0.16)
       ast
       parser (>= 2.6.4.0)
-      sorbet-runtime (>= 0.5.10826)
+      sorbet-runtime (>= 0.5.9204)
       unparser
     regexp_parser (2.8.0)
     rexml (3.2.5)
@@ -173,7 +173,7 @@ GEM
       sorbet-runtime (= 0.5.10826)
     spoom (1.2.1)
       sorbet (>= 0.5.10187)
-      sorbet-runtime (>= 0.5.10826)
+      sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
     tapioca (0.11.6)
       bundler (>= 2.2.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     rbi (0.0.16)
       ast
       parser (>= 2.6.4.0)
-      sorbet-runtime (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.10826)
       unparser
     regexp_parser (2.8.0)
     rexml (3.2.5)
@@ -173,7 +173,7 @@ GEM
       sorbet-runtime (= 0.5.10826)
     spoom (1.2.1)
       sorbet (>= 0.5.10187)
-      sorbet-runtime (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.10826)
       thor (>= 0.19.2)
     tapioca (0.11.6)
       bundler (>= 2.2.25)

--- a/lib/use_packs/private.rb
+++ b/lib/use_packs/private.rb
@@ -371,20 +371,20 @@ module UsePacks
         # TODO: This should probably be `if defined?(CodeOwnership) && CodeOwnership.configured?`
         # but we'll need to add an API to CodeOwnership to do this
         if Pathname.new('config/code_ownership.yml').exist?
-          metadata = {
+          config = {
             'owner' => team.nil? ? 'MyTeam' : team.name
           }
         else
-          metadata = {}
+          config = {}
         end
 
         package = ParsePackwerk::Package.new(
           enforce_dependencies: should_enforce_dependenceies,
           enforce_privacy: enforce_privacy,
           dependencies: [],
-          metadata: metadata,
+          metadata: {},
           name: pack_name,
-          config: {}
+          config: config
         )
 
         ParsePackwerk.write_package_yml!(package)

--- a/spec/use_packs_spec.rb
+++ b/spec/use_packs_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe UsePacks do
       expect(package.enforce_privacy).to eq(true)
       expect(package.enforce_dependencies).to eq(true)
       expect(package.dependencies).to eq([])
-      expect(package.metadata).to eq({ 'owner' => 'MyTeam' })
+      expect(package.config['owner']).to eq('MyTeam')
+      expect(package.metadata).to eq({})
       expect(package.directory.join(RuboCop::Packs::PACK_LEVEL_RUBOCOP_YML).read).to eq(<<~YML)
         Department/SomeCop:
           Enabled: true
@@ -75,8 +76,7 @@ RSpec.describe UsePacks do
       expected = <<~EXPECTED
         enforce_dependencies: true
         enforce_privacy: true
-        metadata:
-          owner: MyTeam # specify your team here, or delete this key if this package is not owned by one team
+        owner: MyTeam # specify your team here, or delete this key if this package is not owned by one team
       EXPECTED
 
       expect(package.yml.read).to eq expected
@@ -116,8 +116,8 @@ RSpec.describe UsePacks do
           enforce_privacy: true,
           enforce_dependencies: false,
           dependencies: [],
-          metadata: { 'owner' => 'MyTeam' },
-          config: {}
+          metadata: {},
+          config: { 'owner' => 'MyTeam' },
         )
 
         ParsePackwerk.bust_cache!
@@ -152,19 +152,20 @@ RSpec.describe UsePacks do
       UsePacks.create_pack!(pack_name: 'packs/my_pack')
       ParsePackwerk.bust_cache!
       package = ParsePackwerk.find('packs/my_pack')
-      expect(package.metadata['owner']).to eq 'MyTeam'
+      expect(package.config['owner']).to eq 'MyTeam'
       package_yml_contents = package.yml.read
       expect(package_yml_contents).to include('owner: MyTeam # specify your team here, or delete this key if this package is not owned by one team')
     end
 
     context 'team owner is provided' do
-      it 'automatically adds the owner metadata key' do
+      it 'automatically adds the owner top-level key' do
         write_codeownership_config
         write_file('config/teams/artists.yml', 'name: Artists')
         UsePacks.create_pack!(pack_name: 'packs/my_pack', team: CodeTeams.find('Artists'))
         ParsePackwerk.bust_cache!
         package = ParsePackwerk.find('packs/my_pack')
-        expect(package.metadata['owner']).to eq 'Artists'
+        expect(package.metadata).to eq({})
+        expect(package.config['owner']).to eq 'Artists'
         package_yml_contents = package.yml.read
         expect(package_yml_contents).to include('owner: Artists')
       end
@@ -197,7 +198,8 @@ RSpec.describe UsePacks do
         expect(package.enforce_privacy).to eq(true)
         expect(package.enforce_dependencies).to eq(true)
         expect(package.dependencies).to eq([])
-        expect(package.metadata).to eq({ 'owner' => 'MyTeam' })
+        expect(package.config['owner']).to eq('MyTeam')
+        expect(package.metadata).to eq({})
         expect(package.directory.join(RuboCop::Packs::PACK_LEVEL_RUBOCOP_YML).read).to eq(<<~YML)
           Department/SomeCop:
             Enabled: true
@@ -206,8 +208,7 @@ RSpec.describe UsePacks do
         expected = <<~EXPECTED
           enforce_dependencies: true
           enforce_privacy: true
-          metadata:
-            owner: MyTeam # specify your team here, or delete this key if this package is not owned by one team
+          owner: MyTeam # specify your team here, or delete this key if this package is not owned by one team
         EXPECTED
 
         expect(package.yml.read).to eq expected

--- a/spec/use_packs_spec.rb
+++ b/spec/use_packs_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe UsePacks do
           enforce_dependencies: false,
           dependencies: [],
           metadata: {},
-          config: { 'owner' => 'MyTeam' },
+          config: { 'owner' => 'MyTeam' }
         )
 
         ParsePackwerk.bust_cache!

--- a/use_packs.gemspec
+++ b/use_packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packs'
-  spec.version       = '0.0.18'
+  spec.version       = '0.0.19'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   # https://bundler.io/blog/2015/03/20/moving-bins-to-exe.html
   spec.executables = %w[packs]
 
-  spec.add_dependency 'code_ownership'
+  spec.add_dependency 'code_ownership', '>= 1.33.0'
   spec.add_dependency 'colorize'
   spec.add_dependency 'packs'
   spec.add_dependency 'packwerk'


### PR DESCRIPTION
Now possible with the new `code_ownership`.